### PR TITLE
fix(server): separate initial state for vue

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,15 +13,19 @@ app.get('/', (req, res) => {
 <html>
 <body>
   <div id="app">
-    <h1>Hello ?name=${escapeHTML(name)}</h1>
+    <h1>Hello ?name={{name}}</h1>
   </div>
   <footer>
   <a href="https://github.com/azu/vue-client-side-template-injection-example">Source Code</a>
   </footer>
   <script src="https://cdn.jsdelivr.net/npm/vue@2.5.13/dist/vue.js"></script>
   <script>
+    window.__INITIAL_STATE__ = ${JSON.stringify({ name })};
+  </script>
+  <script>
       new Vue({
-        el: '#app'
+        el: '#app',
+        data: window.__INITIAL_STATE__ || {}
       });
   </script>
 </body>

--- a/server/index.js
+++ b/server/index.js
@@ -19,13 +19,12 @@ app.get('/', (req, res) => {
   <a href="https://github.com/azu/vue-client-side-template-injection-example">Source Code</a>
   </footer>
   <script src="https://cdn.jsdelivr.net/npm/vue@2.5.13/dist/vue.js"></script>
-  <script>
-    window.__INITIAL_STATE__ = ${JSON.stringify({ name })};
+  <script data-initial-state="${escapeHTML(JSON.stringify({ name }))}">
   </script>
   <script>
       new Vue({
         el: '#app',
-        data: window.__INITIAL_STATE__ || {}
+        data: JSON.parse(document.querySelector("[data-initial-state]").dataset.initialState)
       });
   </script>
 </body>


### PR DESCRIPTION
It will fix client-site template injection issue of the app

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/19714/62680683-bcaa1c80-b9f2-11e9-8680-1e0a48413b73.png">

https://vue-client-side-template-injection-example.azu.now.sh/?name=%7B%7Bthis.constructor.constructor(%27alert(%22foo%22)%27)()%7D%7D

## Changes

- Separate template and data model
- Write `data-initial-state={{State}}` from server
- Use `dataset.initialState` in client